### PR TITLE
build(deps): fix dependency versions

### DIFF
--- a/smoldot-flutter/Cargo.toml
+++ b/smoldot-flutter/Cargo.toml
@@ -9,8 +9,9 @@ crate-type = ["cdylib", "staticlib"]
 [dependencies]
 android_logger = "0.12"
 anyhow = "1"
+curve25519-dalek = "=4.0.0-pre.5"
 env_logger = "0.10.0"
-flutter_rust_bridge = "1"
+flutter_rust_bridge = "<1.62.0"
 lazy_static = "1.4.0"
 log = { version = "0.4.17" }
 simplelog = "0.12.0"


### PR DESCRIPTION
Newer versions released recently caused compilation issues, requiring fixing the versions to last known working versions. Alternative option is to add `cargo.lock` for `smoldot-flutter` to version control, which is probably the better way to do it.